### PR TITLE
Fixes for Retrieve Password

### DIFF
--- a/src/components/FormItem/TextareaFromFile/index.jsx
+++ b/src/components/FormItem/TextareaFromFile/index.jsx
@@ -23,6 +23,7 @@ export default class index extends Component {
     placeholder: PropTypes.string,
     accept: PropTypes.any,
     onChange: PropTypes.func,
+    uploadText: PropTypes.string,
   };
 
   static defaultProps = {
@@ -33,6 +34,7 @@ export default class index extends Component {
       // eslint-disable-next-line no-console
       console.log(values);
     },
+    uploadText: t('Load from local files'),
   };
 
   onChange = (value) => {
@@ -51,7 +53,7 @@ export default class index extends Component {
   };
 
   render() {
-    const { value, placeholder, accept, ...rest } = this.props;
+    const { value, placeholder, accept, uploadText, ...rest } = this.props;
     return (
       <>
         <Input.TextArea
@@ -69,7 +71,7 @@ export default class index extends Component {
           showUploadList={false}
           accept={accept}
         >
-          <Button type="link">{t('Load from local files')}</Button>
+          <Button type="link">{uploadText}</Button>
         </Upload>
       </>
     );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1442,6 +1442,7 @@
   "Load Balancer Name": "Load Balancer Name",
   "Load Balancers": "Load Balancers",
   "Load Template from a file": "Load Template from a file",
+  "Load from Private Key File": "Load from Private Key File",
   "Load from local files": "Load from local files",
   "LoadBalancers Instances": "LoadBalancers Instances",
   "Local": "Local",

--- a/src/locales/ko-kr.json
+++ b/src/locales/ko-kr.json
@@ -1442,6 +1442,7 @@
   "Load Balancer Name": "로드 밸런서 이름",
   "Load Balancers": "로드 밸런서",
   "Load Template from a file": "파일에서 템플릿 불러오기",
+  "Load from Private Key File": "",
   "Load from local files": "로컬 파일에서 불러오기",
   "LoadBalancers Instances": "LoadBalancers 인스턴스",
   "Local": "로컬",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -1442,6 +1442,7 @@
   "Load Balancer Name": "",
   "Load Balancers": "",
   "Load Template from a file": "",
+  "Load from Private Key File": "",
   "Load from local files": "",
   "LoadBalancers Instances": "",
   "Local": "",

--- a/src/locales/zh-hans.json
+++ b/src/locales/zh-hans.json
@@ -1442,6 +1442,7 @@
   "Load Balancer Name": "负载均衡名称",
   "Load Balancers": "负载均衡",
   "Load Template from a file": "从文件加载模板",
+  "Load from Private Key File": "",
   "Load from local files": "从本地文件读取",
   "LoadBalancers Instances": "负载均衡",
   "Local": "本端",

--- a/src/pages/compute/containers/Instance/actions/RetrievePassword.jsx
+++ b/src/pages/compute/containers/Instance/actions/RetrievePassword.jsx
@@ -17,6 +17,7 @@ import JSEncrypt from 'jsencrypt';
 import { ModalAction } from 'containers/Action';
 import globalServerStore from 'stores/nova/instance';
 import globalKeyPairStore from 'stores/nova/keypair';
+// import styles from '../index.less';
 
 export class RetrievePassword extends ModalAction {
   static id = 'retrieve-password';
@@ -85,16 +86,24 @@ export class RetrievePassword extends ModalAction {
         name: 'keypairName',
         label: t('Key Pair Name'),
         type: 'input',
-        readOnly: true,
+        disabled: true,
         tip: t('The Key Pair name that was associated with the instance.'),
+        style: {
+          cursor: 'text',
+          color: '#6e6e6e',
+        },
       },
       {
         name: 'encryptedPassword',
         label: t('Encrypted Password'),
         type: 'textarea',
         tip: t('The instance password encrypted with your public key.'),
-        readOnly: true,
+        disabled: true,
         rows: 4,
+        style: {
+          cursor: 'text',
+          color: '#6e6e6e',
+        },
       },
       {
         name: 'privateKey',
@@ -110,13 +119,20 @@ export class RetrievePassword extends ModalAction {
           'To decrypt your password you will need the private key of your key pair for this instance. Select the private key file, or copy and paste the content of your private key file into the text.'
         ),
         rows: 5,
+        uploadText: t('Load from Private Key File'),
       },
       {
         name: 'password',
         label: t('Password'),
         type: 'input',
-        readOnly: true,
+        disabled: true,
         hidden: this.hidePasswordKeySource,
+        style: {
+          fontFamily: 'monospace',
+          fontSize: '16px',
+          cursor: 'text',
+          color: '#6e6e6e',
+        },
       },
     ];
   }

--- a/src/pages/compute/containers/Instance/actions/index.jsx
+++ b/src/pages/compute/containers/Instance/actions/index.jsx
@@ -80,7 +80,6 @@ const configActions = [
   RevertResize,
   Resize,
   ChangePassword,
-  RetrievePassword,
   Rebuild,
 ];
 
@@ -133,6 +132,9 @@ const actionConfigs = {
       },
       {
         action: ModifyTags,
+      },
+      {
+        action: RetrievePassword,
       },
     ],
   },


### PR DESCRIPTION
# Description:
 - Changed the location of `Retrieve Password` action button from `Config` submenu to main context menu
 - Changed the font size and font family of `Password` field to prevent the confusion of identical alphanumeric chars in decrypted value.
 - Changed the upload button value to `Load from Private Key File`
 - Added `disabled` style
 
 # Screenshot:
 
<img width="772" alt="Screenshot 2023-12-12 at 5 21 37 PM" src="https://github.com/QumulusTechnology/skyline-console/assets/137518216/dcb5e03a-2e8b-4e79-a658-3592e83f7c84">
