### PR TITLE
Volume page fixtures

### DIFF
--- a/src/pages/storage/containers/Volume/index.jsx
+++ b/src/pages/storage/containers/Volume/index.jsx
@@ -77,7 +77,7 @@ export class Volume extends Base {
   }
 
   get isFilterByBackend() {
-    return !this.inDetailPage;
+    return this.inDetailPage;
   }
 
   get isSortByBackend() {


### PR DESCRIPTION
# Description
 - Fixed issue on Volumes listing page partial name searching
 - Volume Creation enhancements and fixtures
   - Available Zone:
     - Set default value
     - Added conditional logic to disable the field when there's only one option
   - Name:
     - Changed the order position from last to second
   - Volume Type:
     - Changed the default value to `__DEFAULT__`
   - Volume Snapshot:
     - Fixed the issue on changing the selected Volume Type depending on the volume type used on the selected value
   - Capacity:
     - Changes the default size value whenever a selection is made from either `Image` or `Volume Snapshot` data source